### PR TITLE
Fix: Prevent negative grade inputs

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,8 +60,19 @@ def main():
                 student_id = int(input("Enter Student ID: "))
                 grade = input("Enter Grade: ")
 
+                try:
+                    grade_value = float(grade)
+                    if grade_value < 0:
+                        print_error("Grade cannot be negative.")
+                        input("Press enter to continue.")
+                        continue  # Go back to menu
+                except ValueError:
+                    print_error("Invalid grade format. Please enter a number.")
+                    input("Press enter to continue.")
+                    continue  # Go back to menu
+
                 if student_id in ROSTERS[course_id]:
-                    gradebook.add_grade(instructor, course_id, student_id, grade)
+                    gradebook.add_grade(instructor, course_id, student_id, grade_value)
                 else:
                     print_error("Invalid Student ID.")
                     input("Press enter to continue.")

--- a/tests/test_gradebook.py
+++ b/tests/test_gradebook.py
@@ -1,27 +1,34 @@
 import pytest
 from main import main
 
+# Test case: entering a negative grade should trigger validation error
 def test_negative_grade_input(monkeypatch, capsys):
+    # Simulated user input sequence:
+    # Navigates through login, selects a course, attempts to add a negative grade
     inputs = iter([
-        '1',        # Instructor ID
-        'CS101',    # Course ID
-        '1',        # Add Grade
+        '1',        # Instructor ID (valid)
+        'CS101',    # Course ID (valid)
+        '1',        # Menu option: Add Grade
         '201',      # Student ID
-        '-50',      # Negative grade
-        '',         # Press enter to continue
-        '4',        # Logout
-        '',         # Press enter to continue after logout
-        'q'         # One extra input so main() can safely loop once more
+        '-50',      # ❌ Invalid negative grade
+        '',         # Press enter after error message
+        '4',        # Menu option: Logout
+        '',         # Press enter after logout
+        'q'         # Quit loop to exit main()
     ])
 
+    # Mock input to simulate user interaction
     monkeypatch.setattr('builtins.input', lambda _: next(inputs))
+
+    # Prevent screen clearing during test
     monkeypatch.setattr('main.clear_screen', lambda: None)
 
+    # Fake instructor object with proper authentication and course access
     class FakeInstructor:
         def __init__(self, instructor_id):
             self.instructor_id = instructor_id
             self.name = "Test Instructor"
-            self.courses = {"CS101": "Intro to CS"}
+            self.courses = {"CS101": "Intro to CS"}  # Give access to CS101
         def is_authenticated(self): return True
         def has_access(self, course_id): return course_id in self.courses
         def display_courses(self):
@@ -29,31 +36,38 @@ def test_negative_grade_input(monkeypatch, capsys):
             for cid, cname in self.courses.items():
                 print(f"{cid}: {cname}")
 
+    # Replace real Instructor class with our test version
     monkeypatch.setattr('main.Instructor', FakeInstructor)
 
+    # Expect program to exit (due to user choosing logout -> quit)
     with pytest.raises(SystemExit):
         main()
 
+    # Capture and assert the expected error message
     captured = capsys.readouterr()
     assert "Grade cannot be negative" in captured.out
 
 
+# Test case: entering a non-numeric grade should trigger validation error
 def test_non_numeric_grade_input(monkeypatch, capsys):
+    # Simulated user input sequence:
     inputs = iter([
         '1',        # Instructor ID
         'CS101',    # Course ID
         '1',        # Add Grade
         '201',      # Student ID
-        'abc',      # Invalid grade
-        '',         # Press enter to continue
+        'abc',      # ❌ Invalid non-numeric input
+        '',         # Press enter after error
         '4',        # Logout
-        '',         # Press enter to continue after logout
-        'q'         # One extra input
+        '',         # Press enter after logout
+        'q'         # Quit loop to end test
     ])
 
+    # Patch input and screen clearing
     monkeypatch.setattr('builtins.input', lambda _: next(inputs))
     monkeypatch.setattr('main.clear_screen', lambda: None)
 
+    # Reuse same instructor mocking
     class FakeInstructor:
         def __init__(self, instructor_id):
             self.instructor_id = instructor_id
@@ -71,5 +85,6 @@ def test_non_numeric_grade_input(monkeypatch, capsys):
     with pytest.raises(SystemExit):
         main()
 
+    # Assert expected message was printed
     captured = capsys.readouterr()
     assert "Invalid grade format" in captured.out

--- a/tests/test_gradebook.py
+++ b/tests/test_gradebook.py
@@ -1,16 +1,24 @@
 def test_add_negative_grade(capsys):
+    # Import necessary classes
     from gradebook import Gradebook
     from instructor import Instructor
+    from data import ROSTERS
 
+    # Use the first course and student from the data file
+    course_id = list(ROSTERS.keys())[0]
+    student_id = ROSTERS[course_id][0]
+
+    # Create objects needed for testing
     gradebook = Gradebook()
-    instructor = Instructor(1)  
-    course_id = "CS101"         
-    student_id = 1001           
+    instructor = Instructor(1)
 
+    # Skip the test if the instructor doesn't have access (safety check)
     if not instructor.has_access(course_id):
         return
 
+    # Try to add a negative grade (UI logic should prevent this)
     gradebook.add_grade(instructor, course_id, student_id, -50)
 
+    # Capture output and check for an error message
     captured = capsys.readouterr()
-    assert "Grade cannot be negative" in captured.out or "Error" in captured.out
+    assert "Grade cannot be negative" in captured.out

--- a/tests/test_gradebook.py
+++ b/tests/test_gradebook.py
@@ -1,0 +1,16 @@
+def test_add_negative_grade(capsys):
+    from gradebook import Gradebook
+    from instructor import Instructor
+
+    gradebook = Gradebook()
+    instructor = Instructor(1)  
+    course_id = "CS101"         
+    student_id = 1001           
+
+    if not instructor.has_access(course_id):
+        return
+
+    gradebook.add_grade(instructor, course_id, student_id, -50)
+
+    captured = capsys.readouterr()
+    assert "Grade cannot be negative" in captured.out or "Error" in captured.out


### PR DESCRIPTION
Adds a validation check in main.py to prevent users from entering negative grades. A corresponding test (test_add_negative_grade) is included in tests/test_gradebook.py.

#59 