### PR TITLE
#9 issue: Fix instructor ID input handling and update test assertion for invali…

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,7 +14,12 @@ def main():
             clear_screen()
             exit()
 
-        instructor_id = int(user_input)
+        try:
+            instructor_id = int(user_input)
+        except ValueError:
+            print_error("Error: Instructor not found")
+            continue
+
         instructor = Instructor(instructor_id)
 
         if not instructor.is_authenticated():
@@ -37,7 +42,7 @@ def main():
 
         while True:
             clear_screen()
-            print(f"\nSelected Course: {course_id}: {COURSES[course_id]["name"]}")
+            print(f"\nSelected Course: {course_id}: {COURSES[course_id]['name']}")
             print("\n1. Add Grade")
             print("2. Edit Grade")
             print("3. View Grades")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -80,7 +80,26 @@ def test_select_valid_course(monkeypatch, capsys, test_instructor):
     # Assert
     captured = capsys.readouterr()
     assert "selected course" in captured.out.lower()
-    assert f"{test_instructor["courses"][0]}".lower() in captured.out.lower()
+    assert f"{test_instructor['courses'][0]}".lower() in captured.out.lower()
     
     # Cleanup
+
+def test_add_course_invalid_instructor(monkeypatch, capsys):
+    #Act & Arrange
+    responses = iter([
+        '1',     # Choose Add Course
+        '3',     # Course ID
+        'awe',   # Course Name
+        '45',    # Invalid Instructor ID
+        'asd',   # Instructor Name
+        'q'      # Quit
+    ])
+    monkeypatch.setattr('builtins.input', lambda _: next(responses))
+
+    with pytest.raises(SystemExit):
+        main()
+
+    captured = capsys.readouterr()
+    assert "Error: Instructor not found" in captured.out
+    assert "Traceback" not in captured.out  # Make sure it doesn't crash
 


### PR DESCRIPTION
**Features**
- Prevents crashes by handling non-numeric instructor ID inputs (e.g., entering awe)
- Standardizes error messages for instructor-related errors
- Ensures test consistency with updated behavior

**Code**
- Wrapped instructor ID input in a try-except block to catch ValueError for invalid (non-numeric) inputs
- Updated the error message in main.py to "Error: Instructor not found" for better clarity and test alignment
- Modified test_add_course_invalid_instructor in test_main.py to match the corrected behavior and expected output

**Brief Code Overview**
- main.py: updated to handle invalid input using try-except and standardize error messaging
- test_main.py: test updated to expect "Error: Instructor not found" message when invalid instructor input is provided

**To test**
- Run the application

Enter a valid numeric instructor ID — the course should be added

Enter a non-numeric instructor ID (e.g., awe) — error should display:
Error: Instructor not found

Run the test suite — all tests including test_add_course_invalid_instructor should pass

