### PR TITLE
Fixed case sensitivity issue to quit program

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ def main():
         clear_screen()
         print("\n--- Gradebook System ---")
         user_input = input("Enter your Instructor ID (q for quit): ")
-        if user_input == 'q':
+        if user_input == 'q' or user_input == 'Q':
             clear_screen()
             exit()
 
@@ -26,7 +26,8 @@ def main():
             clear_screen()
             instructor.display_courses()
             course_id = input("Enter Course ID (q for quit): ")
-            if course_id == 'q':
+            if course_id.lower() == 'q':
+                clear_screen()
                 exit()
 
             if not instructor.has_access(course_id):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,6 +14,23 @@ def test_instructor():
         "invalid_course": "CSabc"
     }
 
+
+# Test quitting at Instructor ID input using 'q' or 'Q'
+@pytest.mark.parametrize("quit_input", ['q', 'Q'])
+def test_quit_on_instructor_input(monkeypatch, quit_input):
+    monkeypatch.setattr('builtins.input', lambda _: quit_input)
+    with pytest.raises(SystemExit):
+        main()
+
+# Test quitting at Course ID input using 'q' or 'Q'
+@pytest.mark.parametrize("quit_input", ['q', 'Q'])
+def test_quit_on_course_id_input(monkeypatch, quit_input):
+    inputs = iter(['101', quit_input])  # Valid instructor ID, then quit
+    monkeypatch.setattr('builtins.input', lambda _: next(inputs))
+    with pytest.raises(SystemExit):
+        main()
+
+
 def test_check_empty_string(monkeypatch,capsys):
     #arrange
     responses = iter(['101','CS101','1','', '201','A','','x','','q'])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,6 +14,21 @@ def test_instructor():
         "invalid_course": "CSabc"
     }
 
+# Test quitting at Instructor ID input using 'q' or 'Q'
+@pytest.mark.parametrize("quit_input", ['q', 'Q'])
+def test_quit_on_instructor_input(monkeypatch, quit_input):
+    monkeypatch.setattr('builtins.input', lambda _: quit_input)
+    with pytest.raises(SystemExit):
+        main()
+
+# Test quitting at Course ID input using 'q' or 'Q'
+@pytest.mark.parametrize("quit_input", ['q', 'Q'])
+def test_quit_on_course_id_input(monkeypatch, quit_input):
+    inputs = iter(['101', quit_input])  # Valid instructor ID, then quit
+    monkeypatch.setattr('builtins.input', lambda _: next(inputs))
+    with pytest.raises(SystemExit):
+        main()
+
 
 # the main function should ask for the user to log in at first
 # test if the user enters an invalid digital id


### PR DESCRIPTION
Fixes #25 – Case-Insensitive Quit Option

Resolved an issue where users could not exit the program using uppercase 'Q'. The quit functionality is now case-insensitive, allowing both 'q' and 'Q' to terminate the program as expected.

Changes made:

Updated input handling to accept both 'q' and 'Q' in all relevant program flows.

Added unit tests to verify that both variants function correctly across all quit scenarios.

This ensures a smoother and more intuitive user experience.