### PR TITLE
Fixed Issue #50 - Invalid Student ID Before Entering Grade

### DIFF
--- a/main.py
+++ b/main.py
@@ -58,9 +58,9 @@ def main():
                     print_information(f"- {sid})")
 
                 student_id = int(input("Enter Student ID: "))
-                grade = input("Enter Grade: ")
 
                 if student_id in ROSTERS[course_id]:
+                    grade = input("Enter Grade: ")
                     gradebook.add_grade(instructor, course_id, student_id, grade)
                 else:
                     print_error("Invalid Student ID.")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -84,3 +84,17 @@ def test_select_valid_course(monkeypatch, capsys, test_instructor):
     
     # Cleanup
 
+#test an invalid student ID
+def test_invalid_studentID(monkeypatch, capsys, test_instructor):
+    # Act & Arrange
+    responses = iter([test_instructor["id"], test_instructor["courses"][0], '1', '1', '4', '', 'q'])
+    monkeypatch.setattr('builtins.input', lambda _: next(responses))
+
+    with pytest.raises(SystemExit) as exitInfo:
+        main()
+
+    # Assert
+    captured = capsys.readouterr()
+    assert "Invalid Student ID." in captured.out
+    
+    # Cleanup


### PR DESCRIPTION
If the user tries to input an invalid Student ID before entering a grade, the program informs the user. Before the program would still prompt for the grade, then inform the user. This update to the code moves the prompt for the grade after the check, thus eliminating an unpolished part in the code.

Issue #50