### PR TITLE
fix: correct input sequence in test_add_course_invalid_instructor

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -98,6 +98,23 @@ def test_select_valid_course(monkeypatch, capsys, test_instructor):
     
     # Cleanup
 
+def test_add_course_invalid_instructor(monkeypatch, capsys):
+    # Arrange
+    responses = iter([
+        '45',  # Invalid Instructor ID
+        'q'    # Quit after invalid attempt
+    ])
+    monkeypatch.setattr('builtins.input', lambda _: next(responses))
+
+    # Act
+    with pytest.raises(SystemExit):
+        main()
+
+    # Assert
+    captured = capsys.readouterr()
+    assert "Invalid Instructor ID" in captured.out
+    assert "Traceback" not in captured.out
+
 def test_sort_courses(mocker, test_instructor):
     mock_input = mocker.patch('builtins.input', side_effect=[test_instructor["id"], test_instructor["courses"][0], '4', 'a', 'x','','q'])
     


### PR DESCRIPTION
- Updated test to match actual input flow in main.py
- Simulates invalid instructor login and confirms graceful exit
- Removed unnecessary inputs (course ID, instructor name) that never get triggered in this flow
- Ensures no traceback appears and proper error message is displayed