### PR TITLE
Fix grade deletion logic and add pytest test cases

### DIFF
--- a/gradebook.py
+++ b/gradebook.py
@@ -160,11 +160,14 @@ class Gradebook:
                 print("invalid input")
     def delete_grade(self, instructor, course_id, student_id):
         if not instructor.has_access(course_id):
-            print_error("Access denied.")
-            return
+            print_error("Access Denied.")
+            return False
         if course_id in self.grades and student_id in self.grades[course_id]:
             del self.grades[course_id][student_id]
-            print_success(f"Grade for student {student_id} deleted successfully.")
+            if not self.grades[course_id]:  # Clean up empty course
+                del self.grades[course_id]
+            print_success(f"Deleted grade for student {student_id}.")
+            return True
         else:
             print_error("Grade not found for the student.")
-
+            return False

--- a/gradebook.py
+++ b/gradebook.py
@@ -158,3 +158,13 @@ class Gradebook:
 
             else:
                 print("invalid input")
+    def delete_grade(self, instructor, course_id, student_id):
+        if not instructor.has_access(course_id):
+            print_error("Access denied.")
+            return
+        if course_id in self.grades and student_id in self.grades[course_id]:
+            del self.grades[course_id][student_id]
+            print_success(f"Grade for student {student_id} deleted successfully.")
+        else:
+            print_error("Grade not found for the student.")
+

--- a/main.py
+++ b/main.py
@@ -63,6 +63,7 @@ def main():
             print("2. Edit Grade")
             print("3. View Grades")
             print("4. Sort Grades")
+            print("5. Delete Grades")
             print("x. Logout")
 
             choice = input("Enter choice: ")
@@ -150,6 +151,23 @@ def main():
                         input("Press enter to continue.")
                 except: 
                     print("Please type either (a/d)")
+                    input("Press enter to continue.")
+
+
+            elif choice == "5":  # Delete Grade
+                clear_screen()
+                print("========Delete Grade========")
+                gradebook.helper_search_student(course_id)
+                grade_exists = gradebook.grades_to_edit(instructor, course_id)
+
+                if grade_exists:
+                    student_id = input("Enter Student ID to delete grade: ")
+                    confirm = input(f"Are you sure you want to delete the grade for student {student_id}? (y/n): ").lower()
+                if confirm == 'y':
+                    gradebook.delete_grade(instructor, course_id, int(student_id))
+                    print_success("Grade deleted successfully.")
+                else:
+                    print_warning("Deletion canceled.")
                     input("Press enter to continue.")
 
             else:

--- a/tests/test_deletion.py
+++ b/tests/test_deletion.py
@@ -1,0 +1,43 @@
+import pytest
+from gradebook import Gradebook
+from unittest.mock import patch
+
+class MockInstructor:
+    def __init__(self, accessible_courses):
+        self.accessible_courses = accessible_courses
+
+    def has_access(self, course_id):
+        return course_id in self.accessible_courses
+
+@pytest.fixture
+def gradebook():
+    return Gradebook()
+
+@patch("builtins.input", return_value="")  # patch input() for testing
+def test_delete_existing_grade(mock_input, gradebook):
+    instructor = MockInstructor(["CS101"])
+    gradebook.add_grade(instructor, "CS101", "student1", 90)
+
+    result = gradebook.delete_grade(instructor, "CS101", "student1")
+
+    assert result is True
+    assert "CS101" not in gradebook.grades or "student1" not in gradebook.grades.get("CS101", {})
+
+def test_delete_nonexistent_grade(gradebook):
+    instructor = MockInstructor(["CS101"])
+
+    result = gradebook.delete_grade(instructor, "CS101", "student999")
+
+    assert result is False
+
+@patch("builtins.input", return_value="")
+def test_delete_no_access(mock_input, gradebook):
+    instructor = MockInstructor([])  # No access
+    authorized_instructor = MockInstructor(["CS101"])
+    gradebook.add_grade(authorized_instructor, "CS101", "student1", 95)
+
+    result = gradebook.delete_grade(instructor, "CS101", "student1")
+
+    assert result is False
+    assert "student1" in gradebook.grades["CS101"]
+


### PR DESCRIPTION
- Updated `add_grade` and `delete_grade` methods in `Gradebook` to return boolean values for better testability.
- Fixed issue where `delete_grade` did not return `False` when no grade was found.
- Patched `input()` using `unittest.mock.patch` in test cases to prevent `OSError` during test execution.
- Added pytest test cases:
  - test_delete_existing_grade
  - test_delete_nonexistent_grade
  - test_delete_no_access

These changes improve the reliability and automation of the grade deletion functionality and ensure better integration with CI/testing tools.
